### PR TITLE
Correction of schema creation by resource result

### DIFF
--- a/src/OpenApi/Complexes/Reflector/ModelReflector.php
+++ b/src/OpenApi/Complexes/Reflector/ModelReflector.php
@@ -376,7 +376,8 @@ class ModelReflector
                 }
             } else {
                 foreach ($model_properties as $model_property) {
-                    if ($model_property->fake_value === $resource_property_value) {
+                    if ($model_property->fake_value === $resource_property_value &&
+                        $model_property->name === $resource_property_name) {
                         $model_property->name = $resource_property_name;
                         $schema_properties[] = $model_property;
                     }


### PR DESCRIPTION
My dear friend.
I noticed that if $cast is an array, then its fake_value is null as well as relation, so when checking, you also need to check the name. 
After testing on your system, everything works fine. If you have any questions, please contact the table opposite.

With love, Dima